### PR TITLE
Write pseudo-atoms to PDB/mmCIF

### DIFF
--- a/ioSPI/atomic_models.py
+++ b/ioSPI/atomic_models.py
@@ -211,7 +211,9 @@ def write_cartesian_coordinates(path, cartesian_coordinates_np=np.random.rand(10
     structure.add_model(gemmi.Model("model"))
     structure.renumber_models()
     structure[0].add_chain("A")
-    structure[0]["A"].add_residue(gemmi.Residue())
+    residue = gemmi.Residue()
+    residue.name = "GLY"
+    structure[0]["A"].add_residue(residue)
 
     for iat in np.arange(cartesian_coordinates_np.shape[0]):
         atom = gemmi.Atom()

--- a/tests/test_atomic_models.py
+++ b/tests/test_atomic_models.py
@@ -87,18 +87,17 @@ class TestAtomicModels:
         path = "test.txt"
         expected = "File format not recognized."
         with pytest.raises(ValueError) as exception_context:
-            _ = write_cartesian_coordinates(path)
+            write_cartesian_coordinates(path)
         actual = str(exception_context.value)
         assert expected in actual
 
     def test_write_cartesian_coordinates_input_shape(self):
         """Test shape of input array."""
-        path = 'test.cif'
-        array = np.empty((1,1))
+        path = "test.cif"
+        array = np.empty((1, 1))
         expected = "Numpy array of cartesian coordinates should be of shape (Natom, 3)."
         with pytest.raises(ValueError) as exception_context:
-            _ = write_cartesian_coordinates(path,
-                                            cartesian_coordinates_np=array)
+            write_cartesian_coordinates(path, cartesian_coordinates_np=array)
         actual = str(exception_context.value)
         assert expected in actual
 

--- a/tests/test_atomic_models.py
+++ b/tests/test_atomic_models.py
@@ -3,6 +3,7 @@
 import os
 
 import gemmi
+import numpy as np
 import pytest
 
 from ..ioSPI.atomic_models import (
@@ -80,6 +81,26 @@ class TestAtomicModels:
         write_atomic_model(path_output, model)
         model = read_atomic_model(path_output, assemble=False)
         assert model.__class__ is gemmi.Model
+
+    def test_write_cartesian_coordinates_filename_extension_error(self):
+        """Test output format is recognized."""
+        path = "test.txt"
+        expected = "File format not recognized."
+        with pytest.raises(ValueError) as exception_context:
+            _ = write_cartesian_coordinates(path)
+        actual = str(exception_context.value)
+        assert expected in actual
+
+    def test_write_cartesian_coordinates_input_shape(self):
+        """Test shape of input array."""
+        path = 'test.cif'
+        array = np.empty((1,1))
+        expected = "Numpy array of cartesian coordinates should be of shape (Natom, 3)."
+        with pytest.raises(ValueError) as exception_context:
+            _ = write_cartesian_coordinates(path,
+                                            cartesian_coordinates_np=array)
+        actual = str(exception_context.value)
+        assert expected in actual
 
     def test_write_cartesian_coordinates_to_pdb(self):
         """Test write_cartesian_coordinates for pdb."""

--- a/tests/test_atomic_models.py
+++ b/tests/test_atomic_models.py
@@ -5,7 +5,11 @@ import os
 import gemmi
 import pytest
 
-from ..ioSPI.atomic_models import read_atomic_model, write_atomic_model
+from ..ioSPI.atomic_models import (
+    read_atomic_model,
+    write_atomic_model,
+    write_cartesian_coordinates,
+)
 
 DATA = "tests/data"
 OUT = ""
@@ -74,5 +78,19 @@ class TestAtomicModels:
         model = read_atomic_model(path_input, assemble=False)
         path_output = os.path.join(OUT, f"test_{cif_filename}")
         write_atomic_model(path_output, model)
+        model = read_atomic_model(path_output, assemble=False)
+        assert model.__class__ is gemmi.Model
+
+    def test_write_cartesian_coordinates_to_pdb(self):
+        """Test write_cartesian_coordinates for pdb."""
+        path_output = os.path.join(OUT, "test_cartesian.pdb")
+        write_cartesian_coordinates(path_output)
+        model = read_atomic_model(path_output, assemble=False)
+        assert model.__class__ is gemmi.Model
+
+    def test_write_cartesian_coordinates_to_cif(self):
+        """Test write_cartesian_coordinates for cif."""
+        path_output = os.path.join(OUT, "test_cartesian.cif")
+        write_cartesian_coordinates(path_output)
         model = read_atomic_model(path_output, assemble=False)
         assert model.__class__ is gemmi.Model


### PR DESCRIPTION
Added function to write a PDB/mmCIF file from a numpy array containing pseudo-atom cartesian coordinates.