### PR TITLE
Documentation on forking to avoid ioSPI tests failing during PRs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,17 @@ See our [contributing](https://github.com/compspi/compspi/blob/master/docs/contr
 ## Note on Pull Requests from Forks
 
 Note that PRs from forks of ioSPI outside the compSPI organization (e.g. other than the main [compSPI/ioSPI](https://github.com/compSPI/ioSPI) repo), will fail on tests, due to an authentication feature that is only available on the main compSPI repo. In order to work around this, please make a feature branch off the main[compSPI/ioSPI](https://github.com/compSPI/ioSPI) repo.
-  1. `git clone https://github.com/compSPI/ioSPI.git`
-  2. `cd ioSPI`
-  3. `git branch iospi_new_feature`
-  4. Develop feature
-  5. PR from `compSPI:iospi_new_feature` to `compSPI:master`
+  1. `git clone https://github.com/compSPI/ioSPI.git`.
+  2. `git branch iospi_new_feature`.
+  3. Develop feature.
+  4. PR from `compSPI:iospi_new_feature` to `compSPI:master`.
 
 If you already have developed a feature branch on your own fork. You can PR into a fresh branch off master.
-  1. Fork the repo to `your_account`: `https://github.com/your_account/ioSPI`
-  2. `git clone https://github.com/your_account/ioSPI.git`
-  3. `cd ioSPI`
-  4. `git branch iospi_new_feature`
-  5. Develop feature
-  6. Make new branch of `compSPI/ioSPI` off of master, e.g. called `compspiorg_iospi_new_feature`
-  7. PR from `your_account:iospi_new_feature` to `compSPI:compspiorg_iospi_new_feature`
-  8. Merge
-  9. PR from `compSPI:compspiorg_iospi_new_feature` to `compSPI:master`
-  10. These tests should pass. You can continue comitting to `compSPI:compspiorg_iospi_new_feature`, and not touch your_account:iospi_new_feature`
+  1. Fork the repo to `your_account`, i.e. `https://github.com/your_account/ioSPI`.
+  2. `git clone https://github.com/your_account/ioSPI.git`.
+  3. `git branch iospi_new_feature`.
+  4. Develop feature.
+  5. Make a fresh branch of `compSPI/ioSPI` off of master, e.g. called `compspiorg_iospi_new_feature`.
+  6. PR from `your_account:iospi_new_feature` to `compSPI:compspiorg_iospi_new_feature`.
+  7. Once merged, PR from `compSPI:compspiorg_iospi_new_feature` to `compSPI:master`.
+  8. These tests should not have authentication issues since they are within branches on the compSPI organization. You can continue comitting to `compSPI:compspiorg_iospi_new_feature`, and not touch `your_account:iospi_new_feature`.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@ With this hook, your code will be automatically formatted with our style convent
 Note that the hooks do not reformat docstrings automatically. If hooks failed with an error related to the documentation, you should correct this error yourself, commit the result and check that the pre-commit marks "Passed".
 
 See our [contributing](https://github.com/compspi/compspi/blob/master/docs/contributing.rst) guidelines!
+
+## Note on Pull Requests from Forks
+
+Note that PRs from forks of ioSPI outside the compSPI organization (e.g. other than the main [compSPI/ioSPI](https://github.com/compSPI/ioSPI) repo), will fail on tests, due to an authentication feature that is only available on the main compSPI repo. In order to work around this, please make a feature branch off the main[compSPI/ioSPI](https://github.com/compSPI/ioSPI) repo.
+  1. `git clone https://github.com/compSPI/ioSPI.git`
+  2. `cd ioSPI`
+  3. `git branch iospi_new_feature`
+  4. Develop feature
+  5. PR from `compSPI:iospi_new_feature` to `compSPI:master`
+
+If you already have developed a feature branch on your own fork. You can PR into a fresh branch off master.
+  1. Fork the repo to `your_account`: `https://github.com/your_account/ioSPI`
+  2. `git clone https://github.com/your_account/ioSPI.git`
+  3. `cd ioSPI`
+  4. `git branch iospi_new_feature`
+  5. Develop feature
+  6. Make new branch of `compSPI/ioSPI` off of master, e.g. called `compspiorg_iospi_new_feature`
+  7. PR from `your_account:iospi_new_feature` to `compSPI:compspiorg_iospi_new_feature`
+  8. Merge
+  9. PR from `compSPI:compspiorg_iospi_new_feature` to `compSPI:master`
+  10. These tests should pass. You can continue comitting to `compSPI:compspiorg_iospi_new_feature`, and not touch your_account:iospi_new_feature`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that PRs from forks of ioSPI outside the compSPI organization (e.g. other t
   3. Develop feature.
   4. PR from `compSPI:iospi_new_feature` to `compSPI:master`.
 
-If you already have developed a feature branch on your own fork. You can PR into a fresh branch off master.
+If you already have developed a feature branch on your own fork, then you can PR into a fresh branch off master. Then do another PR from within the compSPI organization to the master branch.
   1. Fork the repo to `your_account`, i.e. `https://github.com/your_account/ioSPI`.
   2. `git clone https://github.com/your_account/ioSPI.git`.
   3. `git branch iospi_new_feature`.


### PR DESCRIPTION
I put it in the documentation of ioSPI, and not the general contributing guidelines, since it is only an issue for ioSPI.

But if it's a better fit in the contributing guidelines, I can do the PR from the compSPI repo.